### PR TITLE
[BUG]  An alias "filerename" was requested but no service could be found  ZF2.5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,12 @@
         "zendframework/zend-stdlib": "~2.5"
     },
     "require-dev": {
-        "zendframework/zend-filter": "~2.5",
+        "zendframework/zend-filter": "~2.6",
         "zendframework/zend-i18n": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-validator": "~2.5",
+        "zendframework/zend-progressbar": "~2.5",
+        "zendframework/zend-session": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/Transfer/Adapter/FilterPluginManager.php
+++ b/src/Transfer/Adapter/FilterPluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\File\Transfer\Adapter;
 
 use Zend\Filter\FilterPluginManager as BaseManager;
+use Zend\Filter\File;
 
 /**
  * Plugin manager implementation for the filter chain.
@@ -20,16 +21,19 @@ use Zend\Filter\FilterPluginManager as BaseManager;
  */
 class FilterPluginManager extends BaseManager
 {
-    /**
-     * Default set of filters
-     *
-     * @var array
-     */
-    protected $aliases = [
-        'decrypt'   => 'filedecrypt',
-        'encrypt'   => 'fileencrypt',
-        'lowercase' => 'filelowercase',
-        'rename'    => 'filerename',
-        'uppercase' => 'fileuppercase',
-    ];
+
+    public function __construct($configOrContainerInstance = null, array $v3config = []) 
+    {
+	parent::__construct($configOrContainerInstance, $v3config);
+        
+	$this->aliases = array_merge(array(
+            'decrypt'       => File\Decrypt::class,
+            'encrypt'       => File\Encrypt::class,
+            'lowercase'     => File\LowerCase::class,
+            'rename'        => File\Rename::class,
+            'uppercase'     => File\UpperCase::class
+        ), $this->aliases);
+    }
+
 }
+

--- a/test/Transfer/Adapter/AbstractTest.php
+++ b/test/Transfer/Adapter/AbstractTest.php
@@ -301,7 +301,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowPullingFiltersByFile()
     {
-        $this->adapter->addFilter('Boolean', 1, 'foo');
+        $this->adapter->addFilter('Boolean', [1], 'foo');
         $filters = $this->adapter->getFilters('foo');
         $this->assertEquals(1, count($filters));
         $filter = array_shift($filters);

--- a/test/Transfer/Adapter/HttpTestMockAdapter.php
+++ b/test/Transfer/Adapter/HttpTestMockAdapter.php
@@ -18,6 +18,8 @@ use Zend\File\Transfer\Adapter;
  */
 class HttpTestMockAdapter extends Adapter\Http
 {
+    static $aa = true;
+
     public function __construct()
     {
         self::$callbackApc = ['ZendTest\File\Transfer\Adapter\HttpTestMockAdapter', 'apcTest'];
@@ -36,7 +38,7 @@ class HttpTestMockAdapter extends Adapter\Http
 
     public static function isApcAvailable()
     {
-        return true;
+        return static::$aa;
     }
 
     public static function apcTest($id)
@@ -50,7 +52,7 @@ class HttpTestMockAdapter extends Adapter\Http
     }
 
     public function switchApcToUP()
-    {
+    {	static::$aa = false;
         self::$callbackApc = null;
         self::$callbackUploadProgress = ['ZendTest\File\Transfer\Adapter\HttpTestMockAdapter', 'uPTest'];
     }


### PR DESCRIPTION
**Bug with zend-filter 2.6.0** (ZF2.5.3) 

> An alias "filerename" was requested but no service could be found.

Since version 2.6.0 of zend-filter the aliases property is used in Zend\Filter\FilterPluginManager. I merged aliases property in the constructor Zend\File\Transfer\Adapter\FilterPluginManager. 

_Here is a minimal example of the problem I ran into._

``` php
$adp = new Http();
$adp->addFilter('Rename', array('target' => $nameMod.'.dat'));
```

it works and tests pass.
