### PR TITLE
Incorporated feedback from #14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,12 @@
         "zendframework/zend-stdlib": "~2.5"
     },
     "require-dev": {
-        "zendframework/zend-filter": "~2.5",
+        "zendframework/zend-filter": "~2.6",
         "zendframework/zend-i18n": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-validator": "~2.5",
+        "zendframework/zend-progressbar": "~2.5",
+        "zendframework/zend-session": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "zendframework/zend-servicemanager": "~2.5",
         "zendframework/zend-validator": "~2.5",
         "zendframework/zend-progressbar": "~2.5",
-        "zendframework/zend-session": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/Transfer/Adapter/AbstractAdapter.php
+++ b/src/Transfer/Adapter/AbstractAdapter.php
@@ -710,6 +710,7 @@ abstract class AbstractAdapter implements TranslatorAwareInterface
     public function addFilter($filter, $options = null, $files = null)
     {
         if (is_string($filter)) {
+            $options = (null !== $options && is_scalar($options)) ? [$options] : $options;
             $filter = $this->getFilterManager()->get($filter, $options);
         }
 

--- a/src/Transfer/Adapter/FilterPluginManager.php
+++ b/src/Transfer/Adapter/FilterPluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\File\Transfer\Adapter;
 
 use Zend\Filter\FilterPluginManager as BaseManager;
+use Zend\Filter\File;
 
 /**
  * Plugin manager implementation for the filter chain.
@@ -20,16 +21,19 @@ use Zend\Filter\FilterPluginManager as BaseManager;
  */
 class FilterPluginManager extends BaseManager
 {
-    /**
-     * Default set of filters
-     *
-     * @var array
-     */
-    protected $aliases = [
-        'decrypt'   => 'filedecrypt',
-        'encrypt'   => 'fileencrypt',
-        'lowercase' => 'filelowercase',
-        'rename'    => 'filerename',
-        'uppercase' => 'fileuppercase',
-    ];
+
+    public function __construct($configOrContainerInstance = null, array $v3config = []) 
+    {
+	parent::__construct($configOrContainerInstance, $v3config);
+        
+	$this->aliases = array_merge(array(
+            'decrypt'       => File\Decrypt::class,
+            'encrypt'       => File\Encrypt::class,
+            'lowercase'     => File\LowerCase::class,
+            'rename'        => File\Rename::class,
+            'uppercase'     => File\UpperCase::class
+        ), $this->aliases);
+    }
+
 }
+

--- a/src/Transfer/Adapter/FilterPluginManager.php
+++ b/src/Transfer/Adapter/FilterPluginManager.php
@@ -21,19 +21,26 @@ use Zend\Filter\File;
  */
 class FilterPluginManager extends BaseManager
 {
-
-    public function __construct($configOrContainerInstance = null, array $v3config = []) 
+    /**
+     * Constructor
+     *
+     * Merges default aliases pertinent to this plugin manager with those
+     * defined in the parent filter plugin manager.
+     *
+     * @param null|\Zend\ServiceManager\ConfigInterface|\Interop\Container\ContainerInterface $configOrContainerInstance
+     * @param array $v3config If $configOrContainerInstance is a container, this
+     *     value will be passed to the parent constructor.
+     */
+    public function __construct($configOrContainerInstance = null, array $v3config = [])
     {
-	parent::__construct($configOrContainerInstance, $v3config);
-        
-	$this->aliases = array_merge(array(
+        $this->aliases = array_merge([
             'decrypt'       => File\Decrypt::class,
             'encrypt'       => File\Encrypt::class,
             'lowercase'     => File\LowerCase::class,
             'rename'        => File\Rename::class,
-            'uppercase'     => File\UpperCase::class
-        ), $this->aliases);
+            'uppercase'     => File\UpperCase::class,
+        ], $this->aliases);
+
+        parent::__construct($configOrContainerInstance, $v3config);
     }
-
 }
-

--- a/test/Transfer/Adapter/AbstractTest.php
+++ b/test/Transfer/Adapter/AbstractTest.php
@@ -301,7 +301,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowPullingFiltersByFile()
     {
-        $this->adapter->addFilter('Boolean', [1], 'foo');
+        $this->adapter->addFilter('Boolean', 1, 'foo');
         $filters = $this->adapter->getFilters('foo');
         $this->assertEquals(1, count($filters));
         $filter = array_shift($filters);
@@ -412,34 +412,31 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testSettingAndRetrievingOptions()
     {
-        $this->assertEquals(
-            [
-                'bar' => ['ignoreNoFile' => false, 'useByteString' => true],
-                'baz' => ['ignoreNoFile' => false, 'useByteString' => true],
-                'foo' => ['ignoreNoFile' => false, 'useByteString' => true, 'detectInfos' => true],
-                'file_0_' => ['ignoreNoFile' => false, 'useByteString' => true],
-                'file_1_' => ['ignoreNoFile' => false, 'useByteString' => true],
-            ], $this->adapter->getOptions());
+        $this->assertEquals([
+            'bar' => ['ignoreNoFile' => false, 'useByteString' => true],
+            'baz' => ['ignoreNoFile' => false, 'useByteString' => true],
+            'foo' => ['ignoreNoFile' => false, 'useByteString' => true, 'detectInfos' => true],
+            'file_0_' => ['ignoreNoFile' => false, 'useByteString' => true],
+            'file_1_' => ['ignoreNoFile' => false, 'useByteString' => true],
+        ], $this->adapter->getOptions());
 
         $this->adapter->setOptions(['ignoreNoFile' => true]);
-        $this->assertEquals(
-            [
-                'bar' => ['ignoreNoFile' => true, 'useByteString' => true],
-                'baz' => ['ignoreNoFile' => true, 'useByteString' => true],
-                'foo' => ['ignoreNoFile' => true, 'useByteString' => true, 'detectInfos' => true],
-                'file_0_' => ['ignoreNoFile' => true, 'useByteString' => true],
-                'file_1_' => ['ignoreNoFile' => true, 'useByteString' => true],
-            ], $this->adapter->getOptions());
+        $this->assertEquals([
+            'bar' => ['ignoreNoFile' => true, 'useByteString' => true],
+            'baz' => ['ignoreNoFile' => true, 'useByteString' => true],
+            'foo' => ['ignoreNoFile' => true, 'useByteString' => true, 'detectInfos' => true],
+            'file_0_' => ['ignoreNoFile' => true, 'useByteString' => true],
+            'file_1_' => ['ignoreNoFile' => true, 'useByteString' => true],
+        ], $this->adapter->getOptions());
 
         $this->adapter->setOptions(['ignoreNoFile' => false], 'foo');
-        $this->assertEquals(
-            [
-                'bar' => ['ignoreNoFile' => true, 'useByteString' => true],
-                'baz' => ['ignoreNoFile' => true, 'useByteString' => true],
-                'foo' => ['ignoreNoFile' => false, 'useByteString' => true, 'detectInfos' => true],
-                'file_0_' => ['ignoreNoFile' => true, 'useByteString' => true],
-                'file_1_' => ['ignoreNoFile' => true, 'useByteString' => true],
-            ], $this->adapter->getOptions());
+        $this->assertEquals([
+            'bar' => ['ignoreNoFile' => true, 'useByteString' => true],
+            'baz' => ['ignoreNoFile' => true, 'useByteString' => true],
+            'foo' => ['ignoreNoFile' => false, 'useByteString' => true, 'detectInfos' => true],
+            'file_0_' => ['ignoreNoFile' => true, 'useByteString' => true],
+            'file_1_' => ['ignoreNoFile' => true, 'useByteString' => true],
+        ], $this->adapter->getOptions());
     }
 
     public function testGetAllAdditionalFileInfos()
@@ -601,10 +598,9 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     public function testSettingMagicFile()
     {
         $this->adapter->setOptions(['magicFile' => 'test/file']);
-        $this->assertEquals(
-            [
-                'bar' => ['magicFile' => 'test/file', 'ignoreNoFile' => false, 'useByteString' => true],
-            ], $this->adapter->getOptions('bar'));
+        $this->assertEquals([
+            'bar' => ['magicFile' => 'test/file', 'ignoreNoFile' => false, 'useByteString' => true],
+        ], $this->adapter->getOptions('bar'));
     }
 
     /**

--- a/test/Transfer/Adapter/AbstractTest.php
+++ b/test/Transfer/Adapter/AbstractTest.php
@@ -301,7 +301,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowPullingFiltersByFile()
     {
-        $this->adapter->addFilter('Boolean', 1, 'foo');
+        $this->adapter->addFilter('Boolean', [1], 'foo');
         $filters = $this->adapter->getFilters('foo');
         $this->assertEquals(1, count($filters));
         $filter = array_shift($filters);

--- a/test/Transfer/Adapter/HttpTestMockAdapter.php
+++ b/test/Transfer/Adapter/HttpTestMockAdapter.php
@@ -18,8 +18,6 @@ use Zend\File\Transfer\Adapter;
  */
 class HttpTestMockAdapter extends Adapter\Http
 {
-    static $aa = true;
-
     public function __construct()
     {
         self::$callbackApc = ['ZendTest\File\Transfer\Adapter\HttpTestMockAdapter', 'apcTest'];
@@ -38,21 +36,30 @@ class HttpTestMockAdapter extends Adapter\Http
 
     public static function isApcAvailable()
     {
-        return static::$aa;
+        return true;
     }
 
     public static function apcTest($id)
     {
-        return ['total' => 100, 'current' => 100, 'rate' => 10];
+        return [
+            'total' => 100,
+            'current' => 100,
+            'rate' => 10,
+        ];
     }
 
     public static function uPTest($id)
     {
-        return ['bytes_total' => 100, 'bytes_uploaded' => 100, 'speed_average' => 10, 'cancel_upload' => true];
+        return [
+            'bytes_total' => 100,
+            'bytes_uploaded' => 100,
+            'speed_average' => 10,
+            'cancel_upload' => true,
+        ];
     }
 
     public function switchApcToUP()
-    {	static::$aa = false;
+    {
         self::$callbackApc = null;
         self::$callbackUploadProgress = ['ZendTest\File\Transfer\Adapter\HttpTestMockAdapter', 'uPTest'];
     }

--- a/test/Transfer/Adapter/HttpTestMockAdapter.php
+++ b/test/Transfer/Adapter/HttpTestMockAdapter.php
@@ -18,6 +18,8 @@ use Zend\File\Transfer\Adapter;
  */
 class HttpTestMockAdapter extends Adapter\Http
 {
+    static $aa = true;
+
     public function __construct()
     {
         self::$callbackApc = ['ZendTest\File\Transfer\Adapter\HttpTestMockAdapter', 'apcTest'];
@@ -36,7 +38,7 @@ class HttpTestMockAdapter extends Adapter\Http
 
     public static function isApcAvailable()
     {
-        return true;
+        return static::$aa;
     }
 
     public static function apcTest($id)
@@ -50,7 +52,7 @@ class HttpTestMockAdapter extends Adapter\Http
     }
 
     public function switchApcToUP()
-    {
+    {	static::$aa = false;
         self::$callbackApc = null;
         self::$callbackUploadProgress = ['ZendTest\File\Transfer\Adapter\HttpTestMockAdapter', 'uPTest'];
     }


### PR DESCRIPTION
This patch incorporates feedback from #14, specifically:
- Reverts the addition of zend-session to the requirements; it's not used anywhere.
- Reverts changes to `HttpTestMockAdapter`; they did not serve any noticeable purpose.
- Updates `AbstractAdapter` to cast the `$options` value to an array when scalar, ensuring it works with both v2 and v3 versions of zend-servicemanager.
- Updated FilterPluginManager to:
  - Move the `array_merge()` option before the call to the parent constructor; this ensures any configuration passed at instantation takes precedence.
  - Use short array notation for the array passed to `array_merge()`.
  - Document the constructor.
- Updated the `AbstractTest`
  - Reverted the change to `testAdapterShouldAllowPullingFiltersByFile`; it was changing the test to follow observed behavior instead of updating the code to retain existing behavior.
  - Fixed a number of CS issues with regards to multi-line arguments.
