### PR TITLE
Updated dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "zendframework/zend-stdlib": "~2.5"
     },
     "require-dev": {


### PR DESCRIPTION
- Allow installation on PHP 5.5+ OR PHP 7.
- PHP 7 tests are _required_ to pass.
