### PR TITLE
Prepare for zend-servicemanager/zend-stdlib v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $ZEND_SERVICEMANAGER_VERSION != '' ]]; then composer require-dev --no-update "zendframework/zend-servicemanager:$ZEND_SERVICEMANAGER_VERSION" ; fi
   - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer require-dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-validator zendframework/zend-progressbar ; fi
+  - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-progressbar ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
-  - if [[ $ZEND_SERVICEMANAGER_VERSION != '' ]]; then composer require-dev --no-update "zendframework/zend-servicemanager:$ZEND_SERVICEMANAGER_VERSION" ; fi
-  - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer require-dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
+  - if [[ $ZEND_SERVICEMANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$ZEND_SERVICEMANAGER_VERSION" ; fi
+  - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
   - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-progressbar ; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,23 @@ matrix:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
     - php: 7
+    - php: 7
+      env:
+        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
   allow_failures:
     - php: hhvm
 
@@ -33,6 +45,9 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $ZEND_SERVICEMANAGER_VERSION != '' ]]; then composer require-dev --no-update "zendframework/zend-servicemanager:$ZEND_SERVICEMANAGER_VERSION" ; fi
+  - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer require-dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
+  - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-validator zendframework/zend-progressbar ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "zendframework/zend-stdlib": "~2.5"
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-filter": "~2.6",
-        "zendframework/zend-i18n": "~2.5",
-        "zendframework/zend-servicemanager": "~2.5",
+        "zendframework/zend-filter": "^2.6.1",
+        "zendframework/zend-i18n": "^2.6",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-validator": "~2.5",
         "zendframework/zend-progressbar": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "zendframework/zend-filter": "^2.6.1",
         "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "zendframework/zend-validator": "~2.5",
+        "zendframework/zend-validator": "^2.6",
         "zendframework/zend-progressbar": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"

--- a/src/Transfer/Adapter/AbstractAdapter.php
+++ b/src/Transfer/Adapter/AbstractAdapter.php
@@ -290,6 +290,7 @@ abstract class AbstractAdapter implements TranslatorAwareInterface
     public function addValidator($validator, $breakChainOnFailure = false, $options = null, $files = null)
     {
         if (is_string($validator)) {
+            $options = (null !== $options && is_scalar($options)) ? [$options] : $options;
             $validator = $this->getValidatorManager()->get($validator, $options);
             if (is_array($options) && isset($options['messages'])) {
                 if (is_array($options['messages'])) {

--- a/src/Transfer/Adapter/FilterPluginManager.php
+++ b/src/Transfer/Adapter/FilterPluginManager.php
@@ -21,6 +21,21 @@ use Zend\Filter\File;
  */
 class FilterPluginManager extends BaseManager
 {
+    protected $defaultFileFilterAliases = [
+        'decrypt'       => File\Decrypt::class,
+        'Decrypt'       => File\Decrypt::class,
+        'encrypt'       => File\Encrypt::class,
+        'Encrypt'       => File\Encrypt::class,
+        'lowercase'     => File\LowerCase::class,
+        'lowerCase'     => File\LowerCase::class,
+        'LowerCase'     => File\LowerCase::class,
+        'rename'        => File\Rename::class,
+        'Rename'        => File\Rename::class,
+        'uppercase'     => File\UpperCase::class,
+        'upperCase'     => File\UpperCase::class,
+        'UpperCase'     => File\UpperCase::class,
+    ];
+
     /**
      * Constructor
      *
@@ -33,14 +48,7 @@ class FilterPluginManager extends BaseManager
      */
     public function __construct($configOrContainerInstance = null, array $v3config = [])
     {
-        $this->aliases = array_merge([
-            'decrypt'       => File\Decrypt::class,
-            'encrypt'       => File\Encrypt::class,
-            'lowercase'     => File\LowerCase::class,
-            'rename'        => File\Rename::class,
-            'uppercase'     => File\UpperCase::class,
-        ], $this->aliases);
-
+        $this->aliases = array_merge($this->defaultFileFilterAliases, $this->aliases);
         parent::__construct($configOrContainerInstance, $v3config);
     }
 }

--- a/src/Transfer/Adapter/ValidatorPluginManager.php
+++ b/src/Transfer/Adapter/ValidatorPluginManager.php
@@ -9,28 +9,75 @@
 
 namespace Zend\File\Transfer\Adapter;
 
+use Zend\Validator\File;
 use Zend\Validator\ValidatorPluginManager as BaseManager;
 
 class ValidatorPluginManager extends BaseManager
 {
-    protected $aliases = [
-        'count'            => 'filecount',
-        'crc32'            => 'filecrc32',
-        'excludeextension' => 'fileexcludeextension',
-        'excludemimetype'  => 'fileexcludemimetype',
-        'exists'           => 'fileexists',
-        'extension'        => 'fileextension',
-        'filessize'        => 'filefilessize',
-        'hash'             => 'filehash',
-        'imagesize'        => 'fileimagesize',
-        'iscompressed'     => 'fileiscompressed',
-        'isimage'          => 'fileisimage',
-        'md5'              => 'filemd5',
-        'mimetype'         => 'filemimetype',
-        'notexists'        => 'filenotexists',
-        'sha1'             => 'filesha1',
-        'size'             => 'filesize',
-        'upload'           => 'fileupload',
-        'wordcount'        => 'filewordcount',
+    protected $defaultFileValidationAliases = [
+        'count'            => File\Count::class,
+        'Count'            => File\Count::class,
+        'crc32'            => File\Crc32::class,
+        'Crc32'            => File\Crc32::class,
+        'CRC32'            => File\Crc32::class,
+        'excludeextension' => File\ExcludeExtension::class,
+        'excludeExtension' => File\ExcludeExtension::class,
+        'ExcludeExtension' => File\ExcludeExtension::class,
+        'excludemimetype'  => File\ExcludeMimeType::class,
+        'excludeMimeType'  => File\ExcludeMimeType::class,
+        'ExcludeMimeType'  => File\ExcludeMimeType::class,
+        'exists'           => File\Exists::class,
+        'Exists'           => File\Exists::class,
+        'extension'        => File\Extension::class,
+        'Extension'        => File\Extension::class,
+        'filessize'        => File\FilesSize::class,
+        'filesSize'        => File\FilesSize::class,
+        'FilesSize'        => File\FilesSize::class,
+        'hash'             => File\Hash::class,
+        'Hash'             => File\Hash::class,
+        'imagesize'        => File\ImageSize::class,
+        'imageSize'        => File\ImageSize::class,
+        'ImageSize'        => File\ImageSize::class,
+        'iscompressed'     => File\IsCompressed::class,
+        'isCompressed'     => File\IsCompressed::class,
+        'IsCompressed'     => File\IsCompressed::class,
+        'isimage'          => File\IsImage::class,
+        'isImage'          => File\IsImage::class,
+        'IsImage'          => File\IsImage::class,
+        'md5'              => File\Md5::class,
+        'Md5'              => File\Md5::class,
+        'MD5'              => File\Md5::class,
+        'mimetype'         => File\MimeType::class,
+        'mimeType'         => File\MimeType::class,
+        'MimeType'         => File\MimeType::class,
+        'notexists'        => File\NotExists::class,
+        'notExists'        => File\NotExists::class,
+        'NotExists'        => File\NotExists::class,
+        'sha1'             => File\Sha1::class,
+        'Sha1'             => File\Sha1::class,
+        'SHA1'             => File\Sha1::class,
+        'size'             => File\Size::class,
+        'Size'             => File\Size::class,
+        'upload'           => File\Upload::class,
+        'Upload'           => File\Upload::class,
+        'wordcount'        => File\WordCount::class,
+        'wordCount'        => File\WordCount::class,
+        'WordCount'        => File\WordCount::class,
     ];
+
+    /**
+     * Constructor
+     *
+     * Merges default aliases pertinent to this plugin manager with those
+     * defined in the parent filter plugin manager.
+     *
+     * @param null|\Zend\ServiceManager\ConfigInterface|\Interop\Container\ContainerInterface $configOrContainerInstance
+     * @param array $v3config If $configOrContainerInstance is a container, this
+     *     value will be passed to the parent constructor.
+     */
+    public function __construct($configOrContainerInstance = null, array $v3config = [])
+    {
+        $this->aliases = array_merge($this->defaultFileValidationAliases, $this->aliases);
+        parent::__construct($configOrContainerInstance, $v3config);
+    }
 }

--- a/test/Transfer/Adapter/AbstractTest.php
+++ b/test/Transfer/Adapter/AbstractTest.php
@@ -47,13 +47,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldLazyLoadValidatorPluginManager()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $loader = $this->adapter->getValidatorManager();
         $this->assertInstanceOf('Zend\File\Transfer\Adapter\ValidatorPluginManager', $loader);
     }
@@ -68,13 +61,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowAddingValidatorInstance()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $validator = new FileValidator\Count(['min' => 1, 'max' => 1]);
         $this->adapter->addValidator($validator);
         $test = $this->adapter->getValidator('Zend\Validator\File\Count');
@@ -83,13 +69,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowAddingValidatorViaPluginManager()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->adapter->addValidator('Count', false, ['min' => 1, 'max' => 1]);
         $test = $this->adapter->getValidator('Count');
         $this->assertInstanceOf('Zend\Validator\File\Count', $test);
@@ -97,26 +76,12 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterhShouldRaiseExceptionWhenAddingInvalidValidatorType()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->setExpectedException('Zend\File\Transfer\Exception\InvalidArgumentException', 'Invalid validator provided to addValidator');
         $this->adapter->addValidator(new Filter\BaseName);
     }
 
     public function testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $validators = [
             'count' => ['min' => 1, 'max' => 1],
             'Exists' => 'C:\temp',
@@ -144,25 +109,11 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testGetValidatorShouldReturnNullWhenNoMatchingIdentifierExists()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->assertNull($this->adapter->getValidator('Between'));
     }
 
     public function testAdapterShouldAllowPullingValidatorsByFile()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->adapter->addValidator('Between', false, ['min' => 1, 'max' => 5], 'foo');
         $validators = $this->adapter->getValidators('foo');
         $this->assertEquals(1, count($validators));
@@ -172,13 +123,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testCallingSetValidatorsOnAdapterShouldOverwriteExistingValidators()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $validators = [
             new FileValidator\Count(1),
@@ -191,13 +135,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRetrievingValidatorInstancesByClassName()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $ext = $this->adapter->getValidator('Zend\Validator\File\Extension');
         $this->assertInstanceOf('Zend\Validator\File\Extension', $ext);
@@ -205,13 +142,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRetrievingValidatorInstancesByPluginName()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $count = $this->adapter->getValidator('Count');
         $this->assertInstanceOf('Zend\Validator\File\Count', $count);
@@ -219,13 +149,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRetrievingAllValidatorsAtOnce()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $validators = $this->adapter->getValidators();
         $this->assertInternalType('array', $validators);
@@ -237,13 +160,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRemovingValidatorInstancesByClassName()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $this->assertTrue($this->adapter->hasValidator('Zend\Validator\File\Extension'));
         $this->adapter->removeValidator('Zend\Validator\File\Extension');
@@ -252,13 +168,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRemovingValidatorInstancesByPluginName()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $this->assertTrue($this->adapter->hasValidator('Count'));
         $this->adapter->removeValidator('Count');
@@ -267,13 +176,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testRemovingNonexistentValidatorShouldDoNothing()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $validators = $this->adapter->getValidators();
         $this->assertFalse($this->adapter->hasValidator('Between'));
@@ -285,13 +187,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRemovingAllValidatorsAtOnce()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $this->adapter->clearValidators();
         $validators = $this->adapter->getValidators();
@@ -301,51 +196,23 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testValidationShouldReturnTrueForValidTransfer()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->adapter->addValidator('Count', false, [1, 3], 'foo');
         $this->assertTrue($this->adapter->isValid('foo'));
     }
 
     public function testValidationShouldReturnTrueForValidTransferOfMultipleFiles()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->assertTrue($this->adapter->isValid(null));
     }
 
     public function testValidationShouldReturnFalseForInvalidTransfer()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->adapter->addValidator('Extension', false, 'png', 'foo');
         $this->assertFalse($this->adapter->isValid('foo'));
     }
 
     public function testValidationShouldThrowExceptionForNonexistentFile()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->assertFalse($this->adapter->isValid('bogus'));
     }
 
@@ -709,13 +576,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testSetOwnErrorMessage()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $this->adapter->addValidator('Count', false, ['min' => 5, 'max' => 5, 'messages' => [FileValidator\Count::TOO_FEW => 'Zu wenige']]);
         $this->assertFalse($this->adapter->isValid('foo'));
         $message = $this->adapter->getMessages();
@@ -751,13 +611,6 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     public function testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoaderForDifferentFiles()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $validators = [
             ['MimeType', true, ['image/jpeg']], // no files
             ['FilesSize', true, ['max' => '1MB', 'message' => 'файл больше 1MБ']], // no files

--- a/test/Transfer/Adapter/AbstractTest.php
+++ b/test/Transfer/Adapter/AbstractTest.php
@@ -13,7 +13,6 @@ use Interop\Container\ContainerInterface;
 use stdClass;
 use Zend\File;
 use Zend\Filter;
-use Zend\Filter\Word;
 use Zend\Validator;
 use Zend\Validator\File as FileValidator;
 

--- a/test/Transfer/Adapter/AbstractTest.php
+++ b/test/Transfer/Adapter/AbstractTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\File\Transfer\Adapter;
 
+use stdClass;
 use Zend\File;
 use Zend\Filter;
 use Zend\Filter\Word;
@@ -45,6 +46,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldLazyLoadValidatorPluginManager()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $loader = $this->adapter->getValidatorManager();
         $this->assertInstanceOf('Zend\File\Transfer\Adapter\ValidatorPluginManager', $loader);
     }
@@ -58,6 +66,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowAddingValidatorInstance()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $validator = new FileValidator\Count(['min' => 1, 'max' => 1]);
         $this->adapter->addValidator($validator);
         $test = $this->adapter->getValidator('Zend\Validator\File\Count');
@@ -66,6 +81,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowAddingValidatorViaPluginManager()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->adapter->addValidator('Count', false, ['min' => 1, 'max' => 1]);
         $test = $this->adapter->getValidator('Count');
         $this->assertInstanceOf('Zend\Validator\File\Count', $test);
@@ -73,12 +95,26 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterhShouldRaiseExceptionWhenAddingInvalidValidatorType()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->setExpectedException('Zend\File\Transfer\Exception\InvalidArgumentException', 'Invalid validator provided to addValidator');
         $this->adapter->addValidator(new Filter\BaseName);
     }
 
     public function testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $validators = [
             'count' => ['min' => 1, 'max' => 1],
             'Exists' => 'C:\temp',
@@ -106,11 +142,25 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testGetValidatorShouldReturnNullWhenNoMatchingIdentifierExists()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->assertNull($this->adapter->getValidator('Between'));
     }
 
     public function testAdapterShouldAllowPullingValidatorsByFile()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->adapter->addValidator('Between', false, ['min' => 1, 'max' => 5], 'foo');
         $validators = $this->adapter->getValidators('foo');
         $this->assertEquals(1, count($validators));
@@ -120,6 +170,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testCallingSetValidatorsOnAdapterShouldOverwriteExistingValidators()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $validators = [
             new FileValidator\Count(1),
@@ -132,6 +189,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRetrievingValidatorInstancesByClassName()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $ext = $this->adapter->getValidator('Zend\Validator\File\Extension');
         $this->assertInstanceOf('Zend\Validator\File\Extension', $ext);
@@ -139,6 +203,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRetrievingValidatorInstancesByPluginName()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $count = $this->adapter->getValidator('Count');
         $this->assertInstanceOf('Zend\Validator\File\Count', $count);
@@ -146,6 +217,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRetrievingAllValidatorsAtOnce()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $validators = $this->adapter->getValidators();
         $this->assertInternalType('array', $validators);
@@ -157,6 +235,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRemovingValidatorInstancesByClassName()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $this->assertTrue($this->adapter->hasValidator('Zend\Validator\File\Extension'));
         $this->adapter->removeValidator('Zend\Validator\File\Extension');
@@ -165,6 +250,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRemovingValidatorInstancesByPluginName()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $this->assertTrue($this->adapter->hasValidator('Count'));
         $this->adapter->removeValidator('Count');
@@ -173,6 +265,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testRemovingNonexistentValidatorShouldDoNothing()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $validators = $this->adapter->getValidators();
         $this->assertFalse($this->adapter->hasValidator('Between'));
@@ -184,6 +283,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowRemovingAllValidatorsAtOnce()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoader();
         $this->adapter->clearValidators();
         $validators = $this->adapter->getValidators();
@@ -193,23 +299,51 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testValidationShouldReturnTrueForValidTransfer()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->adapter->addValidator('Count', false, [1, 3], 'foo');
         $this->assertTrue($this->adapter->isValid('foo'));
     }
 
     public function testValidationShouldReturnTrueForValidTransferOfMultipleFiles()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->assertTrue($this->adapter->isValid(null));
     }
 
     public function testValidationShouldReturnFalseForInvalidTransfer()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->adapter->addValidator('Extension', false, 'png', 'foo');
         $this->assertFalse($this->adapter->isValid('foo'));
     }
 
     public function testValidationShouldThrowExceptionForNonexistentFile()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->assertFalse($this->adapter->isValid('bogus'));
     }
 
@@ -268,7 +402,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     public function testAdapterhShouldRaiseExceptionWhenAddingInvalidFilterType()
     {
         $this->setExpectedException('Zend\File\Transfer\Exception\InvalidArgumentException', 'Invalid filter specified');
-        $this->adapter->addFilter(new FileValidator\Extension('jpg'));
+        $this->adapter->addFilter(new stdClass());
     }
 
     public function testAdapterShouldAllowAddingMultipleFiltersAtOnceUsingBothInstancesAndPluginLoader()
@@ -573,6 +707,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testSetOwnErrorMessage()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $this->adapter->addValidator('Count', false, ['min' => 5, 'max' => 5, 'messages' => [FileValidator\Count::TOO_FEW => 'Zu wenige']]);
         $this->assertFalse($this->adapter->isValid('foo'));
         $message = $this->adapter->getMessages();
@@ -608,6 +749,13 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     public function testAdapterShouldAllowAddingMultipleValidatorsAtOnceUsingBothInstancesAndPluginLoaderForDifferentFiles()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $validators = [
             ['MimeType', true, ['image/jpeg']], // no files
             ['FilesSize', true, ['max' => '1MB', 'message' => 'файл больше 1MБ']], // no files

--- a/test/Transfer/Adapter/AbstractTest.php
+++ b/test/Transfer/Adapter/AbstractTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\File\Transfer\Adapter;
 
+use Interop\Container\ContainerInterface;
 use stdClass;
 use Zend\File;
 use Zend\Filter;
@@ -59,7 +60,8 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterShouldAllowSettingFilterPluginManagerInstance()
     {
-        $manager = new File\Transfer\Adapter\FilterPluginManager();
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $manager = new File\Transfer\Adapter\FilterPluginManager($container);
         $this->adapter->setFilterManager($manager);
         $this->assertSame($manager, $this->adapter->getFilterManager());
     }
@@ -408,7 +410,7 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
     public function testAdapterShouldAllowAddingMultipleFiltersAtOnceUsingBothInstancesAndPluginLoader()
     {
         $filters = [
-            'Word\SeparatorToCamelCase' => ['separator' => ' '],
+            'wordSeparatorToCamelCase' => ['separator' => ' '],
             [
                 'filter' => 'Boolean',
                 'casting' => true

--- a/test/Transfer/Adapter/HttpTest.php
+++ b/test/Transfer/Adapter/HttpTest.php
@@ -59,6 +59,13 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoSetUploadValidator()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping tests related to validators until zend-validator is updated to '
+                . 'zend-servicemanager v3.'
+            );
+        }
+
         $validators = [
             new FileValidator\Count(1),
             new FileValidator\Extension('jpg'),
@@ -276,6 +283,13 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 
     public function testUploadProgressAdapter()
     {
+        if (! class_exists('Zend\ProgressBar\Adapter\AbstractAdapter')) {
+            $this->markTestSkipped(
+                'Skipping tests related to progress bars until zend-progressbar is updated to '
+                . 'zend-stdlib/zend-servicemanager v3.'
+            );
+        }
+
         if (!Adapter\Http::isApcAvailable() && !Adapter\Http::isUploadProgressAvailable()) {
             $this->markTestSkipped('Whether APC nor UploadExtension available');
         }

--- a/test/Transfer/Adapter/HttpTest.php
+++ b/test/Transfer/Adapter/HttpTest.php
@@ -29,13 +29,6 @@ class HttpTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping HTTP adapter tests until zend-validator is updated to zend-servicemanager v3 '
-                . 'and zend-progressbar is updated to zend-stdlib v3.'
-            );
-        }
-
         $_FILES = [
             'txt' => [
                 'name' => 'test.txt',

--- a/test/Transfer/Adapter/HttpTest.php
+++ b/test/Transfer/Adapter/HttpTest.php
@@ -29,6 +29,13 @@ class HttpTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
+            $this->markTestSkipped(
+                'Skipping HTTP adapter tests until zend-validator is updated to zend-servicemanager v3 '
+                . 'and zend-progressbar is updated to zend-stdlib v3.'
+            );
+        }
+
         $_FILES = [
             'txt' => [
                 'name' => 'test.txt',
@@ -59,13 +66,6 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoSetUploadValidator()
     {
-        if (! interface_exists('Zend\Validator\ValidatorInterface')) {
-            $this->markTestSkipped(
-                'Skipping tests related to validators until zend-validator is updated to '
-                . 'zend-servicemanager v3.'
-            );
-        }
-
         $validators = [
             new FileValidator\Count(1),
             new FileValidator\Extension('jpg'),
@@ -283,13 +283,6 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 
     public function testUploadProgressAdapter()
     {
-        if (! class_exists('Zend\ProgressBar\Adapter\AbstractAdapter')) {
-            $this->markTestSkipped(
-                'Skipping tests related to progress bars until zend-progressbar is updated to '
-                . 'zend-stdlib/zend-servicemanager v3.'
-            );
-        }
-
         if (!Adapter\Http::isApcAvailable() && !Adapter\Http::isUploadProgressAvailable()) {
             $this->markTestSkipped('Whether APC nor UploadExtension available');
         }


### PR DESCRIPTION
This patch prepares zend-file for the v3 releases of zend-servicemanager and zend-stdlib. ~~I'm marking it as a work-in-progress, as I'm unsure it should be completed before zend-validator is completed.~~

Currently, it does the following:
- Updates `composer.json` to use either the v2 or v3 versions of zend-stdlib and zend-servicemanager.
- Updates `composer.json` to use forwards-compatible versions of components that rely on zend-servicemanager, if such versions exist.
- Updates `.travis.yml` to do two jobs per PHP version, one against zend-servicemanager v3, the other against v2.
- Updates `.travis.yml` to remove ~~zend-validator and~~ zend-progressbar from the dev requirements when running against zend-servicemanager v3.
- Updates code to work with zend-servicemanager v3, and updates test expectations where required; some tests are now marked skipped based on dependencies not being forwards-compatible.

~~Unfortunately, `Zend\File\Transfer\Adapter\AbstractAdapter` currently composes both filter and validator plugin managers, and its primary duty is to perform upload validation. The `AbstractTest` is able to skip tests that interact with the validator plugin manager, but the `HttpTest` cannot, as the HTTP adapter sets an initial `Upload` validator during instantiation. Since this is so fundamental, my gut feeling is to wait for zend-validator to be complete before we consider this for merge.~~

**Update**: this patch has been updated to pin against zend-validator `^2.6`, which brings in the forwards-compatibility changes, allowing me to test all functionality except for one or two progress bar items. As such, it's ready.
