### PR TITLE
Ensure progressbar tests can run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $ZEND_SERVICEMANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$ZEND_SERVICEMANAGER_VERSION" ; fi
   - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-progressbar ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,10 @@
     "require-dev": {
         "zendframework/zend-filter": "^2.6.1",
         "zendframework/zend-i18n": "^2.6",
+        "zendframework/zend-progressbar": "^2.5.2",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-session": "^2.6.2",
         "zendframework/zend-validator": "^2.6",
-        "zendframework/zend-progressbar": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/Transfer/Adapter/Http.php
+++ b/src/Transfer/Adapter/Http.php
@@ -288,7 +288,7 @@ class Http extends AbstractAdapter
      */
     public static function getProgress($id = null)
     {
-        if (!static::isApcAvailable() && !static::isUploadProgressAvailable()) {
+        if (!self::isApcAvailable() && !self::isUploadProgressAvailable()) {
             throw new Exception\PhpEnvironmentException('Neither APC nor UploadProgress extension installed');
         }
 
@@ -332,18 +332,18 @@ class Http extends AbstractAdapter
         }
 
         if (!empty($id)) {
-            if (static::isApcAvailable()) {
+            if (self::isApcAvailable()) {
                 $call = call_user_func(static::$callbackApc, ini_get('apc.rfc1867_prefix') . $id);
                 if (is_array($call)) {
                     $status = $call + $status;
                 }
-            } elseif (static::isUploadProgressAvailable()) {
+            } elseif (self::isUploadProgressAvailable()) {
                 $call = call_user_func(static::$callbackUploadProgress, $id);
                 if (is_array($call)) {
                     $status = $call + $status;
-                    $status['total']   = $status['bytes_total'];
-                    $status['current'] = $status['bytes_uploaded'];
-                    $status['rate']    = $status['speed_average'];
+                    $status['total']   = isset($status['bytes_total']) ? $status['bytes_total'] : $status['total'];
+                    $status['current'] = isset($status['bytes_uploaded']) ? $status['bytes_uploaded'] : $status['current'];
+                    $status['rate']    = isset($status['speed_average']) ? $status['speed_average'] : $status['rate'];
                     if ($status['total'] == $status['current']) {
                         $status['done'] = true;
                     }


### PR DESCRIPTION
Since zend-progressbar is updated, it was time to test if the progressbar tests could run. The first hurdle was getting extensions installed; the second was discovering the tests as written could not work.

To fix that, I separated them into discrete APC and UploadProgress tests. From there, I attempted to install the extensions and run each.

As it turns out APC is uninstallable starting in PHP 5.5, so the APC tests cannot run regardless. I decided not to remove the support for now, on the off chance that people have figured out a workaround.

The UploadProgress tests, however, required changes to the mock adapter to allow forcing error situations to occur. I can now verify they actually run and pass.
