### PR TITLE
Fix: Keep packages sorted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
         "file"
     ],
     "homepage": "https://github.com/zendframework/zend-file",
+    "config": {
+        "sort-packages": true
+    },
     "autoload": {
         "psr-4": {
             "Zend\\File\\": "src/"
@@ -17,14 +20,14 @@
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
+        "fabpot/php-cs-fixer": "1.7.*",
+        "phpunit/phpunit": "~4.0",
         "zendframework/zend-filter": "^2.6.1",
         "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-progressbar": "^2.5.2",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-session": "^2.6.2",
-        "zendframework/zend-validator": "^2.6",
-        "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/PHPUnit": "~4.0"
+        "zendframework/zend-validator": "^2.6"
     },
     "suggest": {
         "zendframework/zend-filter": "Zend\\Filter component",


### PR DESCRIPTION
This PR

* [x] keeps packages sorted without the need to specify the `--sort-packages` option

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.