### PR TITLE
Fix: Do not conditionally mark test as skipped

### DIFF
--- a/test/ClassFileLocatorTest.php
+++ b/test/ClassFileLocatorTest.php
@@ -139,10 +139,6 @@ class ClassFileLocatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testIterationShouldNotCountFQCNScalarResolutionConstantAsClass()
     {
-        if (PHP_VERSION_ID < 50500) {
-            $this->markTestSkipped('Only applies to PHP >=5.5');
-        }
-
         foreach (new ClassFileLocator(__DIR__ .'/TestAsset') as $file) {
             if (! preg_match('/ClassNameResolutionCompatibility\.php$/', $file->getFilename())) {
                 continue;


### PR DESCRIPTION
This PR

* [x] removes a useless condition

💁‍♂️ For reference, see 

* https://github.com/zendframework/zend-file/blob/master/composer.json#L16
* https://github.com/zendframework/zend-file/blob/master/.travis.yml#L27-L48