### PR TITLE
spelling fixes

### DIFF
--- a/src/Transfer/Adapter/AbstractAdapter.php
+++ b/src/Transfer/Adapter/AbstractAdapter.php
@@ -923,9 +923,9 @@ abstract class AbstractAdapter implements TranslatorAwareInterface
     }
 
     /**
-     * Retrieve additional internal file informations for files
+     * Retrieve additional internal file information for files
      *
-     * @param  string $file (Optional) File to get informations for
+     * @param  string $file (Optional) File to get information for
      * @return array
      */
     public function getFileInfo($file = null)


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.