### PR TITLE
Enhancement: Raise minimum PHP version to PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,24 +23,6 @@ env:
 
 matrix:
   include:
-    - php: 5.5
-      env:
-        - CS_CHECK=true
-    - php: 5.5
-      env:
-        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
-    - php: 5.6
-      env:
-        - TEST_COVERAGE=true
-        - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
-        - PATH="$HOME/.local/bin:$PATH"
-    - php: 5.6
-      env:
-        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
-    - php: 7.0
-    - php: 7.0
-      env:
-        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
     - php: 7.1
     - php: 7.1
       env:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^7.1",
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "1.7.*",
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "^6.1.4",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-filter": "^2.6.1",
         "zendframework/zend-i18n": "^2.6",

--- a/test/ClassFileLocatorTest.php
+++ b/test/ClassFileLocatorTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\File;
 
+use PHPUnit\Framework;
 use Zend\File\ClassFileLocator;
 use Zend\File\Exception;
 use Zend\File\PhpClassFile;
@@ -18,18 +19,21 @@ use Zend\File\PhpClassFile;
  *
  * @group      Zend_File
  */
-class ClassFileLocatorTest extends \PHPUnit_Framework_TestCase
+class ClassFileLocatorTest extends Framework\TestCase
 {
     public function testConstructorThrowsInvalidArgumentExceptionForInvalidStringDirectory()
     {
-        $this->setExpectedException(Exception\InvalidArgumentException::class);
+        $this->expectException(Exception\InvalidArgumentException::class);
+
         $locator = new ClassFileLocator('__foo__');
     }
 
     public function testConstructorThrowsInvalidArgumentExceptionForNonDirectoryIteratorArgument()
     {
         $iterator = new \ArrayIterator([]);
-        $this->setExpectedException(Exception\InvalidArgumentException::class);
+
+        $this->expectException(Exception\InvalidArgumentException::class);
+
         $locator = new ClassFileLocator($iterator);
     }
 

--- a/test/Transfer/Adapter/AbstractTest.php
+++ b/test/Transfer/Adapter/AbstractTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\File\Transfer\Adapter;
 
 use Interop\Container\ContainerInterface;
+use PHPUnit\Framework;
 use stdClass;
 use Zend\File;
 use Zend\Filter;
@@ -21,7 +22,7 @@ use Zend\Validator\File as FileValidator;
  *
  * @group      Zend_File
  */
-class AbstractTest extends \PHPUnit_Framework_TestCase
+class AbstractTest extends Framework\TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
@@ -75,10 +76,9 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterhShouldRaiseExceptionWhenAddingInvalidValidatorType()
     {
-        $this->setExpectedException(
-            File\Transfer\Exception\InvalidArgumentException::class,
-            'Invalid validator provided to addValidator'
-        );
+        $this->expectException(File\Transfer\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid validator provided to addValidator');
+
         $this->adapter->addValidator(new Filter\BaseName);
     }
 
@@ -272,10 +272,9 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testAdapterhShouldRaiseExceptionWhenAddingInvalidFilterType()
     {
-        $this->setExpectedException(
-            File\Transfer\Exception\InvalidArgumentException::class,
-            'Invalid filter specified'
-        );
+        $this->expectException(File\Transfer\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid filter specified');
+
         $this->adapter->addFilter(new stdClass());
     }
 
@@ -463,10 +462,9 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAdditionalFileInfosForUnknownFile()
     {
-        $this->setExpectedException(
-            File\Transfer\Exception\RuntimeException::class,
-            'The file transfer adapter can not find "unknown"'
-        );
+        $this->expectException(File\Transfer\Exception\RuntimeException::class);
+        $this->expectExceptionMessage('The file transfer adapter can not find "unknown"');
+
         $files = $this->adapter->getFileInfo('unknown');
     }
 
@@ -508,7 +506,9 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionForUnknownHashValue()
     {
-        $this->setExpectedException(File\Transfer\Exception\InvalidArgumentException::class, 'Unknown hash algorithm');
+        $this->expectException(File\Transfer\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown hash algorithm');
+
         $this->adapter->getHash('foo', 'unknown_hash');
     }
 
@@ -541,7 +541,9 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testFileSizeButNoFileFound()
     {
-        $this->setExpectedException(File\Transfer\Exception\InvalidArgumentException::class, 'does not exist');
+        $this->expectException(File\Transfer\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not exist');
+
         $this->assertEquals(10, $this->adapter->getFileSize());
     }
 
@@ -566,7 +568,9 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testMimeTypeButNoFileFound()
     {
-        $this->setExpectedException(File\Transfer\Exception\InvalidArgumentException::class, 'does not exist');
+        $this->expectException(File\Transfer\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not exist');
+
         $this->assertEquals('image/jpeg', $this->adapter->getMimeType());
     }
 
@@ -593,7 +597,9 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $message = $this->adapter->getMessages();
         $this->assertContains('Zu wenige', $message);
 
-        $this->setExpectedException(File\Transfer\Exception\InvalidArgumentException::class, 'does not exist');
+        $this->expectException(File\Transfer\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not exist');
+
         $this->assertEquals('image/jpeg', $this->adapter->getMimeType());
     }
 
@@ -603,7 +609,9 @@ class AbstractTest extends \PHPUnit_Framework_TestCase
         $this->adapter->setDestination($directory, 'nonexisting');
         $this->assertEquals($directory, $this->adapter->getDestination('nonexisting'));
 
-        $this->setExpectedException(File\Transfer\Exception\InvalidArgumentException::class, 'not find');
+        $this->expectException(File\Transfer\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('not find');
+
         $this->assertInternalType('string', $this->adapter->getDestination('reallynonexisting'));
     }
 

--- a/test/Transfer/Adapter/HttpTest.php
+++ b/test/Transfer/Adapter/HttpTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\File\Transfer\Adapter;
 
+use PHPUnit\Framework;
 use Zend\File\Transfer\Adapter;
 use Zend\File\Transfer\Exception\BadMethodCallException;
 use Zend\File\Transfer\Exception\RuntimeException;
@@ -20,7 +21,7 @@ use Zend\Validator;
  *
  * @group      Zend_File
  */
-class HttpTest extends \PHPUnit_Framework_TestCase
+class HttpTest extends Framework\TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
@@ -71,13 +72,15 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 
     public function testSendingFiles()
     {
-        $this->setExpectedException(BadMethodCallException::class, 'not implemented');
+        $this->expectException(BadMethodCallException::class, 'not implemented');
+
         $this->adapter->send();
     }
 
     public function testFileIsSent()
     {
-        $this->setExpectedException(BadMethodCallException::class, 'not implemented');
+        $this->expectException(BadMethodCallException::class, 'not implemented');
+        
         $this->adapter->isSent();
     }
 


### PR DESCRIPTION
This PR

* [x] raises the minimum PHP version from PHP 5.5 to PHP 7.1
* [x] updates `phpunit/phpunit`
* [ ] ...

💁‍♂️ For reference, see http://tinyletter.com/mwopzend/letters/zend-framework-community-news-for-the-week-of-2017-04-20.