### PR TITLE
Fix: Drop HHVM from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,6 @@ matrix:
     - php: 7.1
       env:
         - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
-    - php: hhvm
-    - php: hhvm
-      env:
-        - ZEND_SERVICEMANAGER_VERSION="^2.7.5"
-  allow_failures:
-    - php: hhvm
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi


### PR DESCRIPTION
This PR

* [x] drops HHVM from the Travis build matrix

💁‍♂️ Somewhat related to https://github.com/zendframework/zend-file/pull/39#issuecomment-303506133, but on the other hand, a lot of projects are dropping HHVM, how about us?