### PR TITLE
Fix: Ignore method named after reserved keywords

### DIFF
--- a/src/ClassFileLocator.php
+++ b/src/ClassFileLocator.php
@@ -80,13 +80,22 @@ class ClassFileLocator extends FilterIterator
         $contents = file_get_contents($file->getRealPath());
         $tokens   = token_get_all($contents);
         $count    = count($tokens);
+        $inFunctionDeclaration = false;
         for ($i = 0; $i < $count; $i++) {
             $token = $tokens[$i];
+
+            // single character token found; skip
             if (! is_array($token)) {
-                // single character token found; skip
+                // If we were in a function declaration, and we encounter an
+                // opening paren, reset the $inFunctionDeclaration flag.
+                if ('(' === $token) {
+                    $inFunctionDeclaration = false;
+                }
+
                 $i++;
                 continue;
             }
+
             switch ($token[0]) {
                 case T_NAMESPACE:
                     // Namespace found; grab it for later
@@ -116,10 +125,20 @@ class ClassFileLocator extends FilterIterator
                         $savedNamespace = $namespace;
                     }
                     break;
+                case T_FUNCTION:
+                    $inFunctionDeclaration = true;
+                    break;
                 case T_TRAIT:
                 case T_CLASS:
                     // ignore T_CLASS after T_DOUBLE_COLON to allow PHP >=5.5 FQCN scalar resolution
                     if ($i > 0 && is_array($tokens[$i - 1]) && $tokens[$i - 1][0] === T_DOUBLE_COLON) {
+                        break;
+                    }
+
+                    // Ignore if we are within a function declaration;
+                    // functions are allowed to be named after keywords
+                    // such as class, interface, and trait.
+                    if ($inFunctionDeclaration) {
                         break;
                     }
 
@@ -136,6 +155,13 @@ class ClassFileLocator extends FilterIterator
                     // no break
                 case T_INTERFACE:
                     // Abstract class, class, interface or trait found
+
+                    // Ignore if we are within a function declaration;
+                    // functions are allowed to be named after keywords
+                    // such as class, interface, and trait.
+                    if ($inFunctionDeclaration) {
+                        break;
+                    }
 
                     // Get the classname
                     for ($i++; $i < $count; $i++) {

--- a/test/ClassFileLocatorTest.php
+++ b/test/ClassFileLocatorTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-file for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-file/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\File;
@@ -14,11 +12,6 @@ use Zend\File\ClassFileLocator;
 use Zend\File\Exception;
 use Zend\File\PhpClassFile;
 
-/**
- * Test class for Zend\File\ClassFileLocator
- *
- * @group      Zend_File
- */
 class ClassFileLocatorTest extends TestCase
 {
     public function testConstructorThrowsInvalidArgumentExceptionForInvalidStringDirectory()

--- a/test/ClassFileLocatorTest.php
+++ b/test/ClassFileLocatorTest.php
@@ -177,4 +177,30 @@ class ClassFileLocatorTest extends TestCase
 
         $this->assertEquals($expected, $classNames);
     }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function testIgnoresMethodsNamedAfterKeywords()
+    {
+        $classFileLocator = new ClassFileLocator(__DIR__ . '/TestAsset/WithMethodsNamedAfterKeywords');
+
+        $classFiles = \iterator_to_array($classFileLocator);
+
+        $this->assertCount(2, $classFiles);
+
+        $classNames = \array_reduce($classFiles, function (array $classNames, PhpClassFile $classFile) {
+            return \array_merge(
+                $classNames,
+                $classFile->getClasses()
+            );
+        }, []);
+
+        $expected = [
+            TestAsset\WithMethodsNamedAfterKeywords\WithoutReturnTypeDeclaration::class,
+            TestAsset\WithMethodsNamedAfterKeywords\WithReturnTypeDeclaration::class,
+        ];
+
+        $this->assertEquals($expected, $classNames, '', 0.0, 10, true);
+    }
 }

--- a/test/TestAsset/WithMethodsNamedAfterKeywords/WithReturnTypeDeclaration.php
+++ b/test/TestAsset/WithMethodsNamedAfterKeywords/WithReturnTypeDeclaration.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      https://github.com/zendframework/zend-file for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-file/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\File\TestAsset\WithMethodsNamedAfterKeywords;
+
+final class WithReturnTypeDeclaration
+{
+    public function class(): string
+    {
+    }
+
+    public function interface(): string
+    {
+    }
+
+    public function trait(): string
+    {
+    }
+}

--- a/test/TestAsset/WithMethodsNamedAfterKeywords/WithReturnTypeDeclaration.php
+++ b/test/TestAsset/WithMethodsNamedAfterKeywords/WithReturnTypeDeclaration.php
@@ -1,10 +1,7 @@
 <?php
-
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      https://github.com/zendframework/zend-file for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-file for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-file/blob/master/LICENSE.md New BSD License
  */
 
@@ -12,15 +9,15 @@ namespace ZendTest\File\TestAsset\WithMethodsNamedAfterKeywords;
 
 final class WithReturnTypeDeclaration
 {
-    public function class(): string
+    public function class() : string
     {
     }
 
-    public function interface(): string
+    public function interface() : string
     {
     }
 
-    public function trait(): string
+    public function trait() : string
     {
     }
 }

--- a/test/TestAsset/WithMethodsNamedAfterKeywords/WithoutReturnTypeDeclaration.php
+++ b/test/TestAsset/WithMethodsNamedAfterKeywords/WithoutReturnTypeDeclaration.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      https://github.com/zendframework/zend-file for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-file/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\File\TestAsset\WithMethodsNamedAfterKeywords;
+
+final class WithoutReturnTypeDeclaration
+{
+    public function class()
+    {
+    }
+
+    public function interface()
+    {
+    }
+
+    public function trait()
+    {
+    }
+}

--- a/test/TestAsset/WithMethodsNamedAfterKeywords/WithoutReturnTypeDeclaration.php
+++ b/test/TestAsset/WithMethodsNamedAfterKeywords/WithoutReturnTypeDeclaration.php
@@ -1,10 +1,7 @@
 <?php
-
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      https://github.com/zendframework/zend-file for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-file for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-file/blob/master/LICENSE.md New BSD License
  */
 


### PR DESCRIPTION
This PR

* [x] asserts that `ClassFileLocator` ignores methods named after reserved keywords when they have return type declarations
* [x] adjusts `ClassFileLocator`

💁‍♂️ Ran into a weird issue when `ClassFileLocator` inspected something like

```php
final class Foo
{
    public function class() : string
    {
        return self::class;
    }
}
```

on PHP 7.1 and reported two classes

* `Foo`
* `string`