### PR TITLE
Don't ignore files with `use function`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#44](https://github.com/zendframework/zend-file/pull/44) fixes an issue where ClassFileLocator would skip the file (otherwise valid class file) containing `use function`
 
 ## 2.8.0 - 2018-04-25
 

--- a/src/ClassFileLocator.php
+++ b/src/ClassFileLocator.php
@@ -126,7 +126,10 @@ class ClassFileLocator extends FilterIterator
                     }
                     break;
                 case T_FUNCTION:
-                    $inFunctionDeclaration = true;
+                    // `use function` should not enter function context
+                    if ($i < 2 || ! is_array($tokens[$i - 2]) || $tokens[$i - 2][0] !== T_USE) {
+                        $inFunctionDeclaration = true;
+                    }
                     break;
                 case T_TRAIT:
                 case T_CLASS:

--- a/test/ClassFileLocatorTest.php
+++ b/test/ClassFileLocatorTest.php
@@ -196,4 +196,17 @@ class ClassFileLocatorTest extends TestCase
 
         $this->assertEquals($expected, $classNames, '', 0.0, 10, true);
     }
+
+    public function testIterationFindsClassInAFileWithUseFunction()
+    {
+        $locator = new ClassFileLocator(__DIR__);
+        $found = false;
+
+        foreach ($locator as $file) {
+            if (preg_match('/ContainsUseFunction\.php$/', $file->getFilename())) {
+                $found = true;
+            }
+        }
+        $this->assertTrue($found, "Failed to find a file that contains `use function`");
+    }
 }

--- a/test/TestAsset/ContainsUseFunction.php
+++ b/test/TestAsset/ContainsUseFunction.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ZendTest\File\TestAsset;
+
+use function strlen;
+
+class ContainsUseFunction
+{
+
+}


### PR DESCRIPTION
Previously `ClassFileLocator` would enter a "function context" when it encountered `T_FUNCTION` token, causing it to ignore subsequent classes (thinking they are defined in a function), ultimately leading to the file being ignored because `ClassFileLocator` thought there's no (named) classes defined in the file.

Now it will additionally check that the `T_FUNCTION` token is not preceded by `T_USE`, fixing the bug.

### Steps to reproduce:
 - Create a file, containing a class, and import a function in that class with `use function` (see `ContainsUseFunction.php` in the test asset folder).
 - Create a `ClassFileLocator` for a folder containing that file
 - Iterate over the locator
### Expected
The file should be found, and contain the class
### Actual
The file is ignored

### Checklist
- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.