### PR TITLE
Fix for PHP 7.3: "continue" targeting switch is equivalent to "break"…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,15 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
+    - php: 7.3
+      env:
+        - DEPS=lowest
+    - php: 7.3
+      env:
+        - DEPS=locked
+    - php: 7.3
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#45](https://github.com/zendframework/zend-file/pull/45) fixes compatibility
+  issue with php 7.3 with deprecated continue keyword usage in switch statements
 
 ## 2.8.1 - 2018-05-01
 

--- a/src/Transfer/Adapter/AbstractAdapter.php
+++ b/src/Transfer/Adapter/AbstractAdapter.php
@@ -545,7 +545,7 @@ abstract class AbstractAdapter implements TranslatorAwareInterface
                             break;
 
                         default:
-                            continue;
+                            break;
                     }
                 }
             }


### PR DESCRIPTION
…. Did you mean to use "continue 2"?

From Fedora QA
https://apps.fedoraproject.org/koschei/package/php-zendframework-zend-file?collection=f30