### PR TITLE
fix test for zend-validator 2.11

### DIFF
--- a/test/Transfer/Adapter/HttpTest.php
+++ b/test/Transfer/Adapter/HttpTest.php
@@ -334,6 +334,6 @@ class HttpTest extends TestCase
         $_FILES = [];
         $adapter = new HttpTestMockAdapter();
         $this->assertFalse($adapter->isValidParent());
-        $this->assertContains('exceeds the defined ini size', current($adapter->getMessages()));
+        $this->assertContains('exceeds', current($adapter->getMessages()));
     }
 }


### PR DESCRIPTION
From Fedora QA
https://apps.fedoraproject.org/koschei/package/php-zendframework-zend-file?collection=f30

Since zend-validator 2.11, 1 test fails
```
There was 1 failure:
1) ZendTest\File\Transfer\Adapter\HttpTest::testValidationOfPhpExtendsFormError
Failed asserting that 'File '' exceeds upload_max_filesize directive in php.ini' contains "exceeds the defined ini size".
/builddir/build/BUILD/zend-file-d267733fbc3a15c9ca82708cf6e634e2fabb29e7/test/Transfer/Adapter/HttpTest.php:337

```